### PR TITLE
[PONTI-15] fix(scss) Fix nav link item background color

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -44,3 +44,11 @@ code {
 * {
   box-sizing: border-box;
 }
+
+/***************************************
+      Daisy UI Overrides
+***************************************/
+ul.menu > li > a {
+  background: none;
+  color: white;
+}


### PR DESCRIPTION
## Jira Ticket

https://ponti.atlassian.net/browse/PONTI-15

## Description

This PR fixes an issue where nav link items had a white background by overriding the style from DaisyUI.

## Checklists

- [x] [Is this code high quality?](https://www.notion.so/theponti/Code-Review-Checklist-4c35a8d086f74cabbbcd4248c1f17999)
- [x] [Is this as small as possible?](https://www.notion.so/theponti/Make-Pull-Requests-Small-Again-7ea402269a06448a9ce62f5eebf0a238)
- [x] [Pull Request/Commit conventions](https://www.notion.so/theponti/How-to-write-dank-Commit-Messages-9632eef01cbf4b84ba9a0607db7c91fe)
- [x] **Are these changes tested?**